### PR TITLE
Filter available items by proficiency

### DIFF
--- a/cypress/e2e/campaign/core/armor.cy.js
+++ b/cypress/e2e/campaign/core/armor.cy.js
@@ -11,30 +11,42 @@ describe("armor selection", () => {
     it("has multiple armors available", () => {
       cy.get(".hero-armor-wrapper .hero-item").click();
 
-      cy.get(".hero-armor-wrapper li").should("have.length", 24);
+      cy.get(".hero-armor-wrapper li").should("have.length", 9);
       cy.get(".hero-armor-wrapper li")
         .first()
-        .should("have.text", "Breastplate Plate")
-        .next()
         .should("have.text", "Cloth Armor Cloth")
         .next()
         .should("have.text", "Displacement Cloak Cloth")
         .next()
         .should("have.text", "Dream Weaveplate Cloth | Plate")
         .next()
-        .should("have.text", "Full Plate Armor Plate");
+        .should("have.text", "Greater Displacement Cloak Cloth")
+        .next()
+        .should("have.text", "Greater Spellweave Cloak Cloth");
     });
   it("can set and remove armor", () => {
     cy.get(".hero-armor-wrapper .hero-item").click();
     cy.get(".hero-armor-wrapper li").first().click();
-    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Breastplate");
+    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Cloth Armor");
 
     cy.get(".hero-armor-wrapper .hero-item").click();
     cy.get(".hero-armor-wrapper li").first().next().click();
-    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Cloth Armor");
+    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Displacement Cloak");
 
     cy.reload();
 
+    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Displacement Cloak");
+
+    cy.get("#filter-proficiencies").uncheck();
+
+    cy.get(".hero-armor-wrapper .hero-item").click();
+    cy.get(".hero-armor-wrapper li").first().click();
+    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Breastplate");
+
+    cy.get("#filter-proficiencies").check();
+
+    cy.get(".hero-armor-wrapper .hero-item").click();
+    cy.get(".hero-armor-wrapper li").first().click();
     cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Cloth Armor");
 
     cy.go("back");
@@ -42,28 +54,28 @@ describe("armor selection", () => {
     cy.get(".hero-image").should("not.exist");
   });
   it("can search for a armor", () => {
-    cy.get(".hero-armor-wrapper .hero-item").type("Heavy Th");
+    cy.get(".hero-armor-wrapper .hero-item").type("Runecarved");
     cy.get(".hero-armor-wrapper li").first().click();
-    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Heavy Thornmail");
+    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Runecarved Cloak");
   });
   it("can stash armor", () => {
     cy.get(".hero-armor-wrapper .hero-item").click();
     cy.get(".hero-armor-wrapper li").first().click();
-    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Breastplate");
+    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Cloth Armor");
 
     cy.get(".hero-armor-wrapper .hero-item-stash").click();
     cy.get(".hero-armor-wrapper .hero-item").should("have.value", "");
-    cy.get("#hero-stash-display > li").contains("Breastplate");
+    cy.get("#hero-stash-display > li").contains("Cloth Armor");
 
     cy.reload();
 
     cy.get(".hero-armor-wrapper .hero-item").should("have.value", "");
-    cy.get("#hero-stash-display > li").contains("Breastplate");
+    cy.get("#hero-stash-display > li").contains("Cloth Armor");
   });
   it("can clear armor", () => {
     cy.get(".hero-armor-wrapper .hero-item").click();
     cy.get(".hero-armor-wrapper li").first().click();
-    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Breastplate");
+    cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Cloth Armor");
 
     cy.get(".hero-armor-wrapper .hero-item-clear").click();
     cy.get(".hero-armor-wrapper .hero-item").should("have.value", "");

--- a/cypress/e2e/campaign/core/offHand.cy.js
+++ b/cypress/e2e/campaign/core/offHand.cy.js
@@ -11,59 +11,71 @@ describe("off hand selection", () => {
     it("has multiple off hands available", () => {
       cy.get(".hero-offhand-wrapper .hero-item").click();
 
-      cy.get(".hero-offhand-wrapper li").should("have.length", 25);
+      cy.get(".hero-offhand-wrapper li").should("have.length", 9);
       cy.get(".hero-offhand-wrapper li")
         .first()
-        .should("have.text", "Deadly Backstabber Off Hand Weapon")
+        .should("have.text", "Greater Mystical Symbol Relic")
         .next()
-        .should("have.text", "Deft Stilleto Off Hand Weapon")
+        .should("have.text", "Greater Symbol Of Light Relic")
         .next()
-        .should("have.text", "Dreamcrafted Buckler Off Hand Weapon | Shield")
+        .should("have.text", "Lesser Mystical Symbol Relic")
         .next()
-        .should("have.text", "Dueling Dagger Off Hand Weapon")
+        .should("have.text", "Lesser Symbol Of Light Relic")
         .next()
-        .should("have.text", "Empowered Pact Blade Off Hand Weapon");
+        .should("have.text", "Mystical Symbol Relic");
     });
   it("can set and remove off hand", () => {
     cy.get(".hero-offhand-wrapper .hero-item").click();
     cy.get(".hero-offhand-wrapper li").first().click();
-    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Deadly Backstabber");
+    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Greater Mystical Symbol");
 
     cy.get(".hero-offhand-wrapper .hero-item").click();
     cy.get(".hero-offhand-wrapper li").first().next().click();
-    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Deft Stilleto");
+    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Greater Symbol Of Light");
 
     cy.reload();
 
-    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Deft Stilleto");
+    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Greater Symbol Of Light");
+
+    cy.get("#filter-proficiencies").uncheck();
+
+    cy.get(".hero-offhand-wrapper .hero-item").click();
+    cy.get(".hero-offhand-wrapper li").first().click();
+    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Deadly Backstabber");
+
+    cy.get("#filter-proficiencies").check();
+
+    cy.get(".hero-offhand-wrapper .hero-item").click();
+    cy.get(".hero-offhand-wrapper li").first().click();
+    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Greater Mystical Symbol");
 
     cy.go("back");
     cy.clearLocalStorage();
     cy.get(".hero-image").should("not.exist");
   });
   it("can search for a off hand", () => {
-    cy.get(".hero-offhand-wrapper .hero-item").type("Undermo");
+    cy.get(".hero-offhand-wrapper .hero-item").type("Sigil");
     cy.get(".hero-offhand-wrapper li").first().click();
-    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Undermountain Scabbard");
+    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Sigil Of Honor");
   });
   it("can stash off hand", () => {
     cy.get(".hero-offhand-wrapper .hero-item").click();
     cy.get(".hero-offhand-wrapper li").first().click();
-    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Deadly Backstabber");
+    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Greater Mystical Symbol");
 
     cy.get(".hero-offhand-wrapper .hero-item-stash").click();
     cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "");
-    cy.get("#hero-stash-display > li").contains("Deadly Backstabber");
+    cy.get("#hero-stash-display > li").contains("Greater Mystical Symbol");
 
     cy.reload();
 
     cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "");
-    cy.get("#hero-stash-display > li").contains("Deadly Backstabber");
+    cy.get("#hero-stash-display > li").contains("Greater Mystical Symbol");
   });
   it("can clear off hand", () => {
     cy.get(".hero-offhand-wrapper .hero-item").click();
     cy.get(".hero-offhand-wrapper li").first().click();
-    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Deadly Backstabber");
+    cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "Greater Mystical Symbol");
 
     cy.get(".hero-offhand-wrapper .hero-item-clear").click();
     cy.get(".hero-offhand-wrapper .hero-item").should("have.value", "");

--- a/cypress/e2e/campaign/core/weapon.cy.js
+++ b/cypress/e2e/campaign/core/weapon.cy.js
@@ -11,59 +11,71 @@ describe("weapon selection", () => {
     it("has multiple weapons available", () => {
       cy.get(".hero-weapon-wrapper .hero-item").click();
 
-      cy.get(".hero-weapon-wrapper li").should("have.length", 42);
+      cy.get(".hero-weapon-wrapper li").should("have.length", 13);
       cy.get(".hero-weapon-wrapper li")
         .first()
-        .should("have.text", "Amiran Crossbow Ranged")
+        .should("have.text", "Dreampiercer Bow Implement | Ranged")
         .next()
-        .should("have.text", "Amiran Halberd Heavy | Light")
+        .should("have.text", "Enchanted Crossbow (Cosmic Gem) Ranged | Implement")
         .next()
-        .should("have.text", "Amiran Royal Maul Light")
+        .should("have.text", "Enchanted Crossbow (Socketed) Ranged | Implement")
         .next()
-        .should("have.text", "Battle Maul Light")
+        .should("have.text", "Runecarved Blade Light | Implement")
         .next()
-        .should("have.text", "Blacksteel Blade Heavy");
+        .should("have.text", "Staff Of The Arcana Implement");
     });
   it("can set and remove weapon", () => {
     cy.get(".hero-weapon-wrapper .hero-item").click();
     cy.get(".hero-weapon-wrapper li").first().click();
-    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Amiran Crossbow");
+    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Dreampiercer Bow");
 
     cy.get(".hero-weapon-wrapper .hero-item").click();
     cy.get(".hero-weapon-wrapper li").first().next().click();
-    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Amiran Halberd");
+    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Enchanted Crossbow (Cosmic Gem)");
 
     cy.reload();
 
-    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Amiran Halberd");
+    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Enchanted Crossbow (Cosmic Gem)");
+
+    cy.get("#filter-proficiencies").uncheck();
+
+    cy.get(".hero-weapon-wrapper .hero-item").click();
+    cy.get(".hero-weapon-wrapper li").first().click();
+    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Amiran Crossbow");
+
+    cy.get("#filter-proficiencies").check();
+
+    cy.get(".hero-weapon-wrapper .hero-item").click();
+    cy.get(".hero-weapon-wrapper li").first().click();
+    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Dreampiercer Bow");
 
     cy.go("back");
     cy.clearLocalStorage();
     cy.get(".hero-image").should("not.exist");
   });
   it("can search for a weapon", () => {
-    cy.get(".hero-weapon-wrapper .hero-item").type("Orcish Reaper");
+    cy.get(".hero-weapon-wrapper .hero-item").type("Runecarved");
     cy.get(".hero-weapon-wrapper li").first().click();
-    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Orcish Reaper Blade");
+    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Runecarved Blade");
   });
   it("can stash weapon", () => {
     cy.get(".hero-weapon-wrapper .hero-item").click();
     cy.get(".hero-weapon-wrapper li").first().click();
-    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Amiran Crossbow");
+    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Dreampiercer Bow");
 
     cy.get(".hero-weapon-wrapper .hero-item-stash").click();
     cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "");
-    cy.get("#hero-stash-display > li").contains("Amiran Crossbow");
+    cy.get("#hero-stash-display > li").contains("Dreampiercer Bow");
 
     cy.reload();
 
     cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "");
-    cy.get("#hero-stash-display > li").contains("Amiran Crossbow");
+    cy.get("#hero-stash-display > li").contains("Dreampiercer Bow");
   });
   it("can clear weapon", () => {
     cy.get(".hero-weapon-wrapper .hero-item").click();
     cy.get(".hero-weapon-wrapper li").first().click();
-    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Amiran Crossbow");
+    cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Dreampiercer Bow");
 
     cy.get(".hero-weapon-wrapper .hero-item-clear").click();
     cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "");

--- a/cypress/e2e/campaign/exportCampaign.cy.js
+++ b/cypress/e2e/campaign/exportCampaign.cy.js
@@ -12,18 +12,18 @@ describe("export campaign", () => {
 
       cy.get(".hero-weapon-wrapper .hero-item").click();
       cy.get(".hero-weapon-wrapper li").first().click();
-      cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Amiran Crossbow");
+      cy.get(".hero-weapon-wrapper .hero-item").should("have.value", "Dreampiercer Bow");
 
       cy.get(".hero-armor-wrapper .hero-item").click();
       cy.get(".hero-armor-wrapper li").first().click();
-      cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Breastplate");
+      cy.get(".hero-armor-wrapper .hero-item").should("have.value", "Cloth Armor");
 
       cy.go("back");
       cy.get("#campaign-export").click();
 
       cy.get("#campaign-token").should(
         "have.value",
-        "eyJjYW1wYWlnbiI6ImNvcmUiLCJoZXJvZXMiOlt7Imhlcm9JZCI6ImFya2hhbm9zIiwiY2FtcGFpZ25JZCI6IiIsImVxdWlwbWVudCI6eyJ3ZWFwb25JZCI6ImFtaXJhbi1jcm9zc2JvdyIsIm9mZkhhbmRJZCI6IiIsImFybW9ySWQiOiJicmVhc3RwbGF0ZSIsInRyaW5rZXRJZCI6IiIsImJhZ09uZUlkIjoiIiwiYmFnVHdvSWQiOiIifSwic3Rhc2hlZENhcmRJZHMiOltdLCJza2lsbElkcyI6W10sImF1cmFJZCI6bnVsbCwib3V0Y29tZUlkcyI6W10sInN0YXR1c0lkcyI6W119XX0="
+        "eyJjYW1wYWlnbiI6ImNvcmUiLCJoZXJvZXMiOlt7Imhlcm9JZCI6ImFya2hhbm9zIiwiY2FtcGFpZ25JZCI6IiIsImVxdWlwbWVudCI6eyJ3ZWFwb25JZCI6ImRyZWFtcGllcmNlci1ib3ciLCJvZmZIYW5kSWQiOiIiLCJhcm1vcklkIjoiY2xvdGgtYXJtb3IiLCJ0cmlua2V0SWQiOiIiLCJiYWdPbmVJZCI6IiIsImJhZ1R3b0lkIjoiIn0sInN0YXNoZWRDYXJkSWRzIjpbXSwic2tpbGxJZHMiOltdLCJhdXJhSWQiOm51bGwsIm91dGNvbWVJZHMiOltdLCJzdGF0dXNJZHMiOltdfV19"
       );
       cy.get("#close-modal").click();
 
@@ -37,7 +37,7 @@ describe("export campaign", () => {
       cy.get("#campaign-export").click();
       cy.get("#campaign-token").should(
         "include.value",
-        "eyJjYW1wYWlnbiI6ImNvcmUiLCJoZXJvZXMiOlt7Imhlcm9JZCI6ImFya2hhbm9zIiwiY2FtcGFpZ25JZCI6IiIsImVxdWlwbWVudCI6eyJ3ZWFwb25JZCI6ImFtaXJhbi1jcm9zc2JvdyIsIm9mZkhhbmRJZCI6IiIsImFybW9ySWQiOiJicmVhc3RwbGF0ZSIsInRyaW5rZXRJZCI6IiIsImJhZ09uZUlkIjoiIiwiYmFnVHdvSWQiOiIifSwic3Rhc2hlZENhcmRJZHMiOltdLCJza2lsbElkcyI6WyJkdW5nZW9uLXJvbGUtMSJdLCJhdXJhSWQiOm51bGwsIm91dGNvbWVJZHMiOltdLCJzdGF0dXNJZHMiOltdfV19"
+        "eyJjYW1wYWlnbiI6ImNvcmUiLCJoZXJvZXMiOlt7Imhlcm9JZCI6ImFya2hhbm9zIiwiY2FtcGFpZ25JZCI6IiIsImVxdWlwbWVudCI6eyJ3ZWFwb25JZCI6ImRyZWFtcGllcmNlci1ib3ciLCJvZmZIYW5kSWQiOiIiLCJhcm1vcklkIjoiY2xvdGgtYXJtb3IiLCJ0cmlua2V0SWQiOiIiLCJiYWdPbmVJZCI6IiIsImJhZ1R3b0lkIjoiIn0sInN0YXNoZWRDYXJkSWRzIjpbXSwic2tpbGxJZHMiOlsiZHVuZ2Vvbi1yb2xlLTEiXSwiYXVyYUlkIjpudWxsLCJvdXRjb21lSWRzIjpbXSwic3RhdHVzSWRzIjpbXX1dfQ=="
       );
     });
 });

--- a/src/components/CampaignHeroArmor.vue
+++ b/src/components/CampaignHeroArmor.vue
@@ -3,21 +3,29 @@ import type { ArmorCardData } from "@/data/repository/CardData";
 import { HeroStore } from "@/store/HeroStore";
 import ItemCardSelect from "@/components/ItemCardSelect.vue";
 import type { CardDataRepository } from "@/data/repository/CardDataRepository";
+import type { HeroData } from "@/data/repository/HeroData";
+import { heroCanUse } from "@/data/repository/HeroData";
+import { computed } from "vue";
 
 const heroStore = HeroStore();
 
 const emit = defineEmits(["stash"]);
 const props = defineProps<{
   heroId: string;
+  heroData: HeroData;
   campaignId: string;
   cardsDataRepository: CardDataRepository;
+  filterProficiencies: boolean;
 }>();
 
 const hero = heroStore.findInCampaign(props.heroId, props.campaignId);
 const armorId = hero.equipment.armorId ?? "";
-const offHandCards: ArmorCardData[] = props.cardsDataRepository
-  .findByType("Armor")
-  .map((card) => card as ArmorCardData);
+const offHandCards = computed(() =>
+  props.cardsDataRepository
+    .findByType("Armor")
+    .filter((item) => !props.filterProficiencies || heroCanUse(props.heroData, item))
+    .map((card) => card as ArmorCardData)
+);
 
 function subTypeList(item: ArmorCardData) {
   if (typeof item.armorTypes === "undefined") {

--- a/src/components/CampaignHeroItems.vue
+++ b/src/components/CampaignHeroItems.vue
@@ -7,31 +7,48 @@ import CampaignHeroTrinket from "@/components/CampaignHeroTrinket.vue";
 import CampaignHeroBagItem from "@/components/CampaignHeroBagItem.vue";
 import { HeroStore } from "@/store/HeroStore";
 import { HeroEquipment } from "@/store/Hero";
+import type { HeroData } from "@/data/repository/HeroData";
+import { ref } from "vue";
 
 const heroStore = HeroStore();
 const itemCardDataRepository = new CardDataRepository();
 
 const props = defineProps<{
   heroId: string;
+  hero: HeroData;
   campaignId: string;
 }>();
 
-const hero = heroStore.findInCampaign(props.heroId, props.campaignId);
-if (typeof hero.equipment === "undefined") {
-  hero.equipment = new HeroEquipment();
+const filterProficiencies = ref(true);
+
+const campaignHero = heroStore.findInCampaign(props.heroId, props.campaignId);
+if (typeof campaignHero.equipment === "undefined") {
+  campaignHero.equipment = new HeroEquipment();
 }
 </script>
 
 <template>
   <div class="">
-    <div class="pt-2">
+    <label>
+      <input
+        type="checkbox"
+        v-model="filterProficiencies"
+        id="filter-proficiencies"
+        class="w-5 h-5 text-emerald-500 bg-base-100 rounded shadow border-transparent focus:border-transparent focus:ring-0"
+      />
+      Filter by proficiency
+    </label>
+
+    <div class="pt-4">
       <span>Weapon</span>
     </div>
     <div class="hero-weapon-wrapper">
       <CampaignHeroWeapon
         :campaign-id="campaignId"
         :hero-id="heroId"
+        :hero-data="hero"
         :cards-data-repository="itemCardDataRepository"
+        :filter-proficiencies="filterProficiencies"
         @stash="$emit('stash')"
       />
     </div>
@@ -43,7 +60,9 @@ if (typeof hero.equipment === "undefined") {
       <CampaignHeroOffHand
         :campaign-id="campaignId"
         :hero-id="heroId"
+        :hero-data="hero"
         :cards-data-repository="itemCardDataRepository"
+        :filter-proficiencies="filterProficiencies"
         @stash="$emit('stash')"
       >
       </CampaignHeroOffHand>
@@ -56,7 +75,9 @@ if (typeof hero.equipment === "undefined") {
       <CampaignHeroArmor
         :campaign-id="campaignId"
         :hero-id="heroId"
+        :hero-data="hero"
         :cards-data-repository="itemCardDataRepository"
+        :filter-proficiencies="filterProficiencies"
         @stash="$emit('stash')"
       >
       </CampaignHeroArmor>

--- a/src/components/CampaignHeroOffHand.vue
+++ b/src/components/CampaignHeroOffHand.vue
@@ -3,21 +3,29 @@ import type { OffHandCardData } from "@/data/repository/CardData";
 import { HeroStore } from "@/store/HeroStore";
 import ItemCardSelect from "@/components/ItemCardSelect.vue";
 import type { CardDataRepository } from "@/data/repository/CardDataRepository";
+import type { HeroData } from "@/data/repository/HeroData";
+import { heroCanUse } from "@/data/repository/HeroData";
+import { computed } from "vue";
 
 const heroStore = HeroStore();
 
 const emit = defineEmits(["stash"]);
 const props = defineProps<{
   heroId: string;
+  heroData: HeroData;
   campaignId: string;
   cardsDataRepository: CardDataRepository;
+  filterProficiencies: boolean;
 }>();
 
 const hero = heroStore.findInCampaign(props.heroId, props.campaignId);
 const offHandId = hero.equipment.offHandId ?? "";
-const offHandCards: OffHandCardData[] = props.cardsDataRepository
-  .findByType("Off Hand")
-  .map((card) => card as OffHandCardData);
+const offHandCards = computed(() =>
+  props.cardsDataRepository
+    .findByType("Off Hand")
+    .filter((item) => !props.filterProficiencies || heroCanUse(props.heroData, item))
+    .map((card) => card as OffHandCardData)
+);
 
 function subTypeList(item: OffHandCardData) {
   return item.offHandTypes.join(" | ");

--- a/src/components/CampaignHeroWeapon.vue
+++ b/src/components/CampaignHeroWeapon.vue
@@ -3,20 +3,28 @@ import type { WeaponCardData } from "@/data/repository/CardData";
 import { HeroStore } from "@/store/HeroStore";
 import ItemCardSelect from "@/components/ItemCardSelect.vue";
 import type { CardDataRepository } from "@/data/repository/CardDataRepository";
+import type { HeroData } from "@/data/repository/HeroData";
+import { heroCanUse } from "@/data/repository/HeroData";
+import { computed } from "vue";
 
 const heroStore = HeroStore();
 
 const emit = defineEmits(["stash"]);
 const props = defineProps<{
   heroId: string;
+  heroData: HeroData;
   campaignId: string;
   cardsDataRepository: CardDataRepository;
+  filterProficiencies: boolean;
 }>();
 
 const hero = heroStore.findInCampaign(props.heroId, props.campaignId);
-const weaponCards: WeaponCardData[] = props.cardsDataRepository
-  .findByType("Weapon")
-  .map((card) => card as WeaponCardData);
+const weaponCards = computed(() =>
+  props.cardsDataRepository
+    .findByType("Weapon")
+    .filter((item) => !props.filterProficiencies || heroCanUse(props.heroData, item))
+    .map((item) => item as WeaponCardData)
+);
 
 let selectedId = hero.equipment.weaponId;
 

--- a/src/data/repository/HeroData.ts
+++ b/src/data/repository/HeroData.ts
@@ -5,6 +5,13 @@ import type { HeroRace } from "@/data/type/HeroRace";
 import type { WeaponType } from "@/data/type/WeaponType";
 import type { OffHandType } from "@/data/type/OffHandType";
 import type { ArmorType } from "@/data/type/ArmorType";
+import type { CardData } from "@/data/repository/CardData";
+import type { ArmorCardData, OffHandCardData, WeaponCardData } from "@/data/repository/CardData";
+import {
+  instanceOfArmorCardData,
+  instanceOfOffHandCardData,
+  instanceOfWeaponCardData,
+} from "@/data/repository/CardData";
 
 export interface HeroData {
   id: string;
@@ -24,4 +31,23 @@ export interface HeroData {
     miniature: string;
     list: string;
   };
+}
+
+export function heroCanUse(hero: HeroData, item: CardData): boolean {
+  if (instanceOfArmorCardData(item)) {
+    return (item as ArmorCardData).armorTypes.some((armorType) =>
+      hero.proficiencies.armor.some((armorProficiency) => armorProficiency === armorType)
+    );
+  }
+  if (instanceOfOffHandCardData(item)) {
+    return (item as OffHandCardData).offHandTypes.some((offHandType) =>
+      hero.proficiencies.offHand.some((offHandProficiency) => offHandProficiency === offHandType)
+    );
+  }
+  if (instanceOfWeaponCardData(item)) {
+    return (item as WeaponCardData).weaponTypes.some((weaponType) =>
+      hero.proficiencies.weapon.some((weaponProficiency) => weaponProficiency === weaponType)
+    );
+  }
+  return true;
 }

--- a/src/views/HeroDetailView.vue
+++ b/src/views/HeroDetailView.vue
@@ -44,7 +44,7 @@ function onStash() {
     <BaseDivider :alt="true">Equipment</BaseDivider>
 
     <div class="py-2 w-full">
-      <CampaignHeroItems :campaign-id="campaignId" :hero-id="heroId" @stash="onStash" />
+      <CampaignHeroItems :campaign-id="campaignId" :hero-id="heroId" :hero="hero" @stash="onStash" />
     </div>
 
     <BaseDivider :alt="true">Stash</BaseDivider>


### PR DESCRIPTION
Available items for Weapon, Off Hand, and Armor are filtered based on the hero's proficiency to make it easier to find items.

Some classes have abilities that let them equip items regardless of proficiency (like the Bard class' "Fashionist" in the Harlequin tree). A checkbox is included so that one can optionally display all items for these cases. The checkbox's default state is checked, and it will return to that state by navigating back and forth to the hero detail view.

