### PR TITLE
Changed playwright config to default vue cli one

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://127.0.0.1:5173/drunagor-helper/",
+    baseURL: "http://localhost:5173/drunagor-helper/",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -70,8 +70,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run dev",
-    url: "http://127.0.0.1:5173",
+    command: process.env.CI ? "vite preview --port 5173" : "vite dev",
+    port: 5173,
     reuseExistingServer: !process.env.CI,
     timeout: 5 * 1000,
   },


### PR DESCRIPTION
in a completely new vue project with playwright created with the cli the default playwright config looks a bit different. tested it with this default and locally it works perfectly. Also I wouldnt have to add --host 127.0.0.1 to the npm run dev script.